### PR TITLE
bump acmidm-login-service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
     restart: always
     logging: *default-logging
   login:
-    image: lblod/acmidm-login-service:feature-configurable
+    image: lblod/acmidm-login-service:0.10.0-beta.1
     environment:
       MU_APPLICATION_AUTH_DISCOVERY_URL: "https://authenticatie-ti.vlaanderen.be/op/.well-known/openid-configuration"
       MU_APPLICATION_AUTH_CLIENT_ID: "69069b1c-0bd0-4679-a9af-5a265c544c1c"


### PR DESCRIPTION
This PR updates the acmidm-login-service to 0.10.0-beta.1 which fixes an issue with the groupId not being passed correctly.