### PR TITLE
Add migrations to clear bestuurseenheden and set up mock account for abb

### DIFF
--- a/config/migrations/20220919095447-remove-bestuurseenheden.sparql
+++ b/config/migrations/20220919095447-remove-bestuurseenheden.sparql
@@ -1,0 +1,42 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+
+DELETE {
+  GRAPH ?g {
+      ?account a foaf:OnlineAccount;
+            ?accountP ?accountO.
+      ?persoon a foaf:Person;
+            foaf:member ?bestuurseenheid;
+            foaf:account ?account;
+            ?personP ?personO.
+  }
+  GRAPH <http://mu.semte.ch/graphs/public> {
+      ?bestuurseenheid a besluit:Bestuurseenheid;
+                      mu:uuid ?uuid;
+                      ?bestuurseenheidP ?bestuurseenheidO.
+      ?account a foaf:OnlineAccount;
+            ?accountP ?accountO.
+      ?persoon a foaf:Person;
+            foaf:member ?bestuurseenheid;
+            foaf:account ?account;
+            ?personP ?personO.
+  }
+}
+WHERE {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    ?bestuurseenheid a besluit:Bestuurseenheid;
+                    mu:uuid ?uuid;
+                    ?bestuurseenheidP ?bestuurseenheidO.
+    ?account a foaf:OnlineAccount;
+            ?accountP ?accountO.
+    ?persoon a foaf:Person;
+            foaf:member ?bestuurseenheid;
+            foaf:account ?account;
+            ?personP ?personO.
+  }
+    BIND(IRI(CONCAT("http://mu.semte.ch/graphs/organizations/",?uuid)) AS ?g )
+    FILTER(?uuid != "141d9d6b-54af-4d17-b313-8d1c30bc3f5b")
+}

--- a/config/migrations/20220919111308-set-up-abb-mock-account.sparql
+++ b/config/migrations/20220919111308-set-up-abb-mock-account.sparql
@@ -1,0 +1,31 @@
+PREFIX mu: <http://mu.semte.ch/vocabularies/core/>
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX besluit: <http://data.vlaanderen.be/ns/besluit#>
+
+INSERT DATA {
+  GRAPH <http://mu.semte.ch/graphs/public> {
+    <http://data.lblod.info/id/persoon/8826c15b-cd4f-414e-a16a-4260776450ba> a foaf:Person;
+           mu:uuid "8826c15b-cd4f-414e-a16a-4260776450ba";
+           foaf:firstName "Mock";
+           foaf:familyName "Agentschap Binnenlands Bestuur";
+           foaf:member <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>;
+           foaf:account <http://data.lblod.info/id/account/ca9b170c-73b0-412b-81a1-6f655464ee6d>.
+    <http://data.lblod.info/id/account/ca9b170c-73b0-412b-81a1-6f655464ee6d> a foaf:OnlineAccount;
+           mu:uuid "ca9b170c-73b0-412b-81a1-6f655464ee6d";
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "ABBLBLODGebruiker-Superadmin".
+           }
+  GRAPH <http://mu.semte.ch/graphs/organizations/141d9d6b-54af-4d17-b313-8d1c30bc3f5b> {
+    <http://data.lblod.info/id/persoon/8826c15b-cd4f-414e-a16a-4260776450ba> a foaf:Person;
+           mu:uuid "8826c15b-cd4f-414e-a16a-4260776450ba";
+           foaf:firstName "Mock";
+           foaf:familyName "Agentschap Binnenlands Bestuur";
+           foaf:member <http://data.lblod.info/id/bestuurseenheden/141d9d6b-54af-4d17-b313-8d1c30bc3f5b>;
+           foaf:account <http://data.lblod.info/id/account/ca9b170c-73b0-412b-81a1-6f655464ee6d>.
+    <http://data.lblod.info/id/account/ca9b170c-73b0-412b-81a1-6f655464ee6d> a foaf:OnlineAccount;
+           mu:uuid "ca9b170c-73b0-412b-81a1-6f655464ee6d";
+           foaf:accountServiceHomepage <https://github.com/lblod/mock-login-service>;
+           ext:sessionRole "ABBLBLODGebruiker-Superadmin".
+           }
+}


### PR DESCRIPTION
This PR includes migrations for:
- removing all organizations and their accounts except for the ABB organization.
- adding a mock account for the ABB organization,
Solves https://binnenland.atlassian.net/jira/software/c/projects/GN/boards/4?modal=detail&selectedIssue=GN-3602