### PR TITLE
GN-4330: remove unused type predicate on codelists

### DIFF
--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -209,11 +209,6 @@
         }
       },
       "relationships": {
-        "type": {
-          "predicate": "dct:type",
-          "target": "skos-concept",
-          "cardinality": "one"
-        },
         "publisher": {
           "predicate": "dct:publisher",
           "target": "administrative-unit",


### PR DESCRIPTION
-------

### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Now that we decide the single/multi property of codelist per-template, this predicate is no longer needed.
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->
[frontend pr](https://github.com/lblod/frontend-reglementaire-bijlage/pull/174)
[GN-4330](https://binnenland.atlassian.net/browse/GN-4330)

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

Can't really think of a situation this would break under
### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->


Codelists that already have this type will remain in the database for backwards compatibility (hence the lack of migration).

### Checks PR readiness
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations