### PR TITLE
Bump mu-identifier to 1.10.1 (hotfix)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       EMBER_OAUTH_API_SCOPE: "openid vo profile abb_lblod"
       EMBER_VARIABLE_PLUGIN_ENDPOINT: '/raw-sparql'
   identifier:
-    image: semtech/mu-identifier:1.9.1
+    image: semtech/mu-identifier:1.10.1
     environment:
       DEFAULT_MU_AUTH_ALLOWED_GROUPS_HEADER: "[{\"variables\":[],\"name\":\"public\"}]"
       SESSION_COOKIE_SECURE: "on"


### PR DESCRIPTION
### Overview
This PR bumps the mu-identifier service to 1.10.1
