### PR TITLE
update frontend to 7.2.2

### DIFF
--- a/.changeset/plenty-ads-shake.md
+++ b/.changeset/plenty-ads-shake.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Use correct URL in footer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   frontend:
-    image: lblod/frontend-reglementaire-bijlage:7.2.1
+    image: lblod/frontend-reglementaire-bijlage:7.2.2
     restart: always
     environment:
       EMBER_OAUTH_API_REDIRECT_URL: "https://reglementairebijlagen.lblod.info/authorization/callback"


### PR DESCRIPTION
### Overview
This PR updates the frontend to 7.2.2, which includes a fix of the website URL in the footer.
