### PR TITLE
Remove unresolvable resource relationships

### DIFF
--- a/.changeset/fresh-timers-tan.md
+++ b/.changeset/fresh-timers-tan.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Remove unresolvable relationships

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -179,19 +179,9 @@
         }
       },
       "relationships": {
-        "instruction": {
-          "predicate": "ext:instructionVariable",
-          "target": "template",
-          "cardinality": "one"
-        },
         "code-list": {
           "predicate": "ext:codeList",
           "target": "code-list",
-          "cardinality": "one"
-        },
-        "expects": {
-          "predicate": "ext:expects",
-          "target": "shape",
           "cardinality": "one"
         }
       },

--- a/config/resources/goverment.json
+++ b/config/resources/goverment.json
@@ -58,22 +58,22 @@
       "relationships": {
         "administrative-unit": {
           "predicate": "besluit:bestuurt",
-          "target": "administrative-units",
+          "target": "administrative-unit",
           "cardinality": "one"
         },
         "classification": {
           "predicate": "org:classification",
-          "target": "governing-body-classification-codes",
+          "target": "administrative-unit-classification-code",
           "cardinality": "one"
         },
         "is-time-specialization-of": {
           "predicate": "generiek:isTijdspecialisatieVan",
-          "target": "governing-bodies",
+          "target": "governing-body",
           "cardinality": "one"
         },
         "has-time-specializations": {
           "predicate": "generiek:isTijdspecialisatieVan",
-          "target": "governing-bodies",
+          "target": "governing-body",
           "cardinality": "many",
           "inverse": true
         }


### PR DESCRIPTION
### Overview
The recent update to `mu-cl-resources` 1.23.0 includes some changes in the handling of undefined resource models.
This PR ensures that relationships pointing to undefined models are removed.
Specifically, the following relationships have been removed:
- `mapping.instruction`
- `mapping.expects`

The following relationships have been corrected:
- `governing-body.administrative-unit`
- `governing-body.classification`
- `governing-body.is-time-specialization-of`
- `governing-body.has-time-specializations`

These errors are probably a combination of mistakes in plurality/singularity; and copying model definitions from the MOW application.

##### connected issues and PRs:
https://github.com/lblod/app-gelinkt-notuleren/pull/178

### How to test/reproduce
- run `mu project doc` and observe that the generation of `json:api` docs executes without errors

### Challenges/uncertainties
I noticed that there are also mistakes in the model names/definitions in the frontend. Will fix those in a seperate PR.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
