### PR TITLE
Cleanup resource definitions

### DIFF
--- a/.changeset/angry-snails-search.md
+++ b/.changeset/angry-snails-search.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Drop unused `attachment` model

--- a/.changeset/good-moons-itch.md
+++ b/.changeset/good-moons-itch.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Drop unused `mapping` model

--- a/.changeset/loud-kangaroos-fry.md
+++ b/.changeset/loud-kangaroos-fry.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Drop unnecessary `starred` and `origin` properties of `editor-document` model

--- a/.changeset/shiny-bags-wink.md
+++ b/.changeset/shiny-bags-wink.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Drop unnecessary/unused `status` property from `document-container` model

--- a/.changeset/yellow-elephants-obey.md
+++ b/.changeset/yellow-elephants-obey.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Drop unused `editor-document-statuses` model

--- a/.woodpecker/validate-resource-models.yml
+++ b/.woodpecker/validate-resource-models.yml
@@ -1,0 +1,11 @@
+steps:
+  validate-resource-models:
+    image: madnificent/cl-resources-plantuml-generator
+    commands:
+      - mkdir /config/output
+      - cp -R ./config/resources/* /app/configuration/
+      - cd /
+      - sbcl --disable-debugger --load /usr/src/startup.lisp
+when:
+  event:
+    - pull_request

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -166,29 +166,6 @@
       },
       "new-resource-base": "http://data.lblod.info/concepts/"
     },
-    "mappings": {
-      "name": "mapping",
-      "class": "ext:Mapping",
-      "attributes": {
-        "variable": {
-          "type": "string",
-          "predicate": "ext:variable"
-        },
-        "type": {
-          "type": "string",
-          "predicate": "ext:variableType"
-        }
-      },
-      "relationships": {
-        "code-list": {
-          "predicate": "ext:codeList",
-          "target": "code-list",
-          "cardinality": "one"
-        }
-      },
-      "features": ["include-uri"],
-      "new-resource-base": "http://data.lblod.info/mappings/"
-    },
     "code-lists": {
       "name": "code-list",
       "class": "lblodmow:Codelist",
@@ -204,12 +181,6 @@
           "predicate": "dct:publisher",
           "target": "administrative-unit",
           "cardinality": "one"
-        },
-        "mappings": {
-          "predicate": "ext:codeList",
-          "target": "mapping",
-          "cardinality": "many",
-          "inverse": true
         }
       },
       "features": ["include-uri"],

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -6,7 +6,8 @@
     "dct": "http://purl.org/dc/terms/",
     "dbpedia": "http://dbpedia.org/ontology/",
     "nie": "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#",
-    "gn": "http://data.lblod.info/vocabularies/gelinktnotuleren/"
+    "gn": "http://data.lblod.info/vocabularies/gelinktnotuleren/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
   },
   "resources": {
     "files": {

--- a/config/resources/editor.json
+++ b/config/resources/editor.json
@@ -37,14 +37,6 @@
             "updated-on": {
               "type": "datetime",
               "predicate": "pav:lastUpdateOn"
-            },
-            "starred": {
-              "type": "boolean",
-              "predicate": "tmp:starred"
-            },
-            "origin": {
-              "type": "string",
-              "predicate": "pav:providedBy"
             }
         },
         "relationships": {

--- a/config/resources/editor.json
+++ b/config/resources/editor.json
@@ -110,17 +110,6 @@
         },
         "new-resource-base": "http://data.lblod.info/document-containers/"
       },
-      "editor-document-statuses": {
-        "name": "editor-document-status",
-        "class": "ext:EditorDocumentStatus",
-        "attributes": {
-          "name": {
-            "type": "string",
-            "predicate": "ext:EditorDocumentStatusName"
-          }
-        },
-        "new-resource-base": "http://data.lblod.info/editor-document-statuses/"
-      },
       "editor-document-folders": {
         "name": "editor-document-folder",
         "class": "ext:EditorDocumentFolder",

--- a/config/resources/editor.json
+++ b/config/resources/editor.json
@@ -75,11 +75,6 @@
               "target": "editor-document",
               "cardinality": "one"
             },
-            "status": {
-              "predicate": "ext:editorDocumentStatus",
-              "target": "skos-concept",
-              "cardinality": "one"
-            },
             "folder": {
               "predicate": "ext:editorDocumentFolder",
               "target": "editor-document-folder",

--- a/config/resources/editor.json
+++ b/config/resources/editor.json
@@ -90,11 +90,6 @@
               "target": "editor-document",
               "cardinality": "many"
             },
-            "attachments": {
-              "predicate": "ext:hasAttachments",
-              "target": "attachment",
-              "cardinality": "many"
-            },
             "published-version": {
               "predicate": "prov:derivedFrom",
               "target": "published-regulatory-attachment-container",
@@ -136,35 +131,6 @@
           }
         },
         "new-resource-base": "http://data.lblod.info/editor-document-folders/"
-      },
-      "attachments": {
-        "name": "attachment",
-        "class": "ext:Attachment",
-        "attributes": {
-          "decision": {
-            "type": "uri",
-            "predicate": "dct:isPartOf"
-          }
-        },
-        "relationships": {
-          "document-container": {
-            "predicate": "ext:hasAttachments",
-            "target": "document-container",
-            "cardinality": "one",
-            "inverse": true
-          },
-          "file": {
-            "predicate": "ext:hasFile",
-            "target": "file",
-            "cardinality": "one"
-          },
-          "type": {
-            "predicate": "ext:attachmentType",
-            "target": "skos-concept",
-            "cardinality": "one"
-          }
-        },
-        "new-resource-base": "http://lblod.data.gift/attachment/"
       }
   }
 }


### PR DESCRIPTION
### Overview
While working on the decision template-builder feature, I noticed that the backend still contained quite a few unused/unnecessary resource definitions.
This PR drops the following definitions/relationships:
- The `mapping` model and `mappings` relationship
- The `editor-document-statuses` model
- The `attachment` model and `attachments` relationship
- The `status` relationship on the `document-container` model
- The `starred` and `origin` attributes of the `editor-document` model

##### connected issues and PRs:
https://github.com/lblod/frontend-reglementaire-bijlage/pull/229

### How to test/reproduce
- This PR should not change the functionality of the app
- Run `mu project doc` and observe that the generation of json:api docs executes without errors

### Challenges/uncertainties
It seems that a lot of these definitions/relationships/attributes came over from other applications (MOW and GN), and were never removed.

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
