### PR TITLE
Introduce single `/tasks/:id` route used for fetching task information

### DIFF
--- a/.changeset/fast-tips-taste.md
+++ b/.changeset/fast-tips-taste.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Update `lblod/reglement-publish-service` to 4.1.0

--- a/.changeset/hot-knives-repair.md
+++ b/.changeset/hot-knives-repair.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Update frontend to version 8.3.1

--- a/.changeset/popular-trees-prove.md
+++ b/.changeset/popular-trees-prove.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Introduce `/tasks/:id` endpoint used for fetching task information

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -115,12 +115,16 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/published-snippets/"
   end
 
-  match "/regulatory-attachment-publication-tasks/*path", %{ accept: %{json: true}, layer: :api} do
+  post "/regulatory-attachment-publication-tasks/*path", %{ accept: %{json: true}, layer: :api} do
     Proxy.forward conn, path, "http://publisher/regulatory-attachment-publication-tasks/"
   end
 
-  match "/snippet-list-publication-tasks/*path", %{ accept: %{json: true}, layer: :api} do
+  post "/snippet-list-publication-tasks/*path", %{ accept: %{json: true}, layer: :api} do
     Proxy.forward conn, path, "http://publisher/snippet-list-publication-tasks/"
+  end
+
+  get "/tasks/*path", %{ accept: %{json: true}, layer: :api} do
+    Proxy.forward conn, path, "http://publisher/tasks/"
   end
 
   match "/snippet-lists/*path", %{ accept: %{json: true}, layer: :api} do

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       BACKEND_HOST: database
     restart: always
   publisher:
-    image: lblod/reglement-publish-service:4.0.0
+    image: lblod/reglement-publish-service:4.1.0
     links:
       - database:database
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   frontend:
-    image: lblod/frontend-reglementaire-bijlage:8.3.0
+    image: lblod/frontend-reglementaire-bijlage:8.3.1
     restart: always
     environment:
       EMBER_OAUTH_API_REDIRECT_URL: "https://reglementairebijlagen.lblod.info/authorization/callback"


### PR DESCRIPTION
### Overview
This PR introduces some changes in the routes used for fetching the status/information of a specific task.
- It replaces the GET `/snippet-list-publication-tasks/:id` and GET `/regulatory-attachment-publication-tasks/:id` by a single GET `/tasks/:id` endpoint.
- Unnecessary/unused information has been removed from the response body when fetching information of a task.

##### connected issues and PRs:
https://github.com/lblod/reglement-publish-service/pull/12
https://github.com/lblod/frontend-reglementaire-bijlage/pull/233

### Setup
<details>
<summary>docker-compose.override.yml</summary>

```yml
version: "3.4"
services:
  publisher:
    image: !reset null
    build: https://github.com/lblod/reglement-publish-service.git#refactor/task-fetch-route
  frontend:
    image: !reset null
    build: https://github.com/lblod/frontend-reglementaire-bijlage.git#refactor/task-fetch-route
```
</details>

### How to test/reproduce
- Start the application
- Visit the snippet edit page/template publish pages
- Save the content of a snippet/publish a template
- Notice that `/tasks/:id` endpoint is now used to fetch the info of a task

### Challenges/uncertainties
We should probably also refactor the `POST` endpoints with regards to request and response bodies.

Note: the introduction of `/tasks/:id` endpoint does mean that this service no longer follows the JSON:API spec. 
Before this PR was added, this service (incorrectly) followed the `JSON:API` spec in order to  more-or-less guarantee compatibility with ember-data. Unsure if we should strive to maintain `JSON:API` spec compatibility or not.

As described before, this PR removes some properties from the response body returned by the different endpoints. At first sight, the removed fields (`taskType` and `document-container`) were not used/necessary.

### Checks PR readiness
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] npm lint
