### PR TITLE
Add vendor proxy service

### DIFF
--- a/.changeset/twenty-colts-kneel.md
+++ b/.changeset/twenty-colts-kneel.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": minor
+---
+
+Add vendor-proxy service

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -80,6 +80,16 @@ defmodule Dispatcher do
     forward conn, path, "http://codex-proxy/sparql/"
   end
 
+  options "/vendor-proxy/*path", _ do
+    conn
+    |> Plug.Conn.put_resp_header( "access-control-allow-headers", "content-type,accept" )
+    |> Plug.Conn.put_resp_header( "access-control-allow-methods", "*" )
+    |> send_resp( 200, "{ \"message\": \"ok\" }" )
+  end
+
+  match "/vendor-proxy/*path" do
+    forward conn, path, "http://vendor-proxy/"
+  end
   #######################################################################
   # editor.json                                                         #
   #######################################################################

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,3 +126,12 @@ services:
     image: lblod/codex-reverse-proxy-service
     logging: *default-logging
     restart: always
+
+  vendor-proxy:
+    image: lblod/vendor-proxy-service:0.1.0
+    environment:
+      QUERY_BASE_URL: 'https://mandatenbeheer.lblod.info'
+      VENDOR_KEY: 'secret'
+      VENDOR_URI: 'http://data.lblod.info/vendors/75ad4503-1699-4e43-8cab-a494142ae571'
+      AUTH_GROUP: 'org'
+


### PR DESCRIPTION
### Overview
<!-- high level overview of changes (not just "implement ticket") + *why* + design document, special notes like ticket partially implemented etc. -->

Adds the vendor proxy service to RB, for use with the person variable plugin.
The ability to fill in person variables (rather than only inserting placeholders, is not an explicit requirement for RB, but I'd prefer to keep the variables features consistent.

We might not need this anymore once we move to ldes, but itll be useful for testing until we're there.
##### connected issues and PRs:
<!-- links to connected jira tickets -->
<!-- Link to PRs that are related (and in what way) -->

[GN-4876](https://binnenland.atlassian.net/browse/GN-4876)


### Setup
<!-- PR dependencies -->
<!-- override snippets -->

You need the overrides for the secret and the ID, ask on rocket if you don't have them

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [x] changelog
- [x] no new deprecations
