### PR TITLE
Add imported resources list to snippet list resource

### DIFF
--- a/.changeset/healthy-boats-act.md
+++ b/.changeset/healthy-boats-act.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": minor
+---
+
+Add imported resources to snippet list model

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -215,6 +215,10 @@
         "label": {
           "type": "string",
           "predicate": "skos:prefLabel"
+        },
+        "imported-resources": {
+          "type": "string-set",
+          "predicate": "say:snippetImportedResource"
         }
       },
       "relationships": {

--- a/config/resources/repository.lisp
+++ b/config/resources/repository.lisp
@@ -40,3 +40,4 @@
 (add-prefix "nie" "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#")
 (add-prefix "dbpedia" "http://dbpedia.org/ontology/")
 (add-prefix "gn" "http://data.lblod.info/vocabularies/gelinktnotuleren/")
+(add-prefix "say" "https://say.data.gift/ns/")


### PR DESCRIPTION
### Overview
To allow for storing the collected imported resources on the snippet list, so documents know what resource links are needed.

##### connected issues and PRs:
Used by https://github.com/lblod/ember-rdfa-editor-lblod-plugins/pull/462
Needed for testing https://github.com/lblod/frontend-reglementaire-bijlage/pull/263
For Jira ticket [GN-4898](https://binnenland.atlassian.net/browse/GN-4898)

### Setup
Run [the frontend PR](https://github.com/lblod/frontend-reglementaire-bijlage/pull/263) to test.

### How to test/reproduce
See instructions in frontend PR.

### Challenges/uncertainties
We weren't currently using the say: namespace for any resources which gave me a doubt about whether to use it. It also uses https rather than http as used by other x.data.gift namespaces, which seems strange, but this is what is being used in the plugins repo.

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
