### PR TITLE
Remove vendor-proxy service

### DIFF
--- a/.changeset/ninety-gorillas-smell.md
+++ b/.changeset/ninety-gorillas-smell.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": minor
+---
+
+Remove vendor-proxy service as templates should be municipality agnostic, so it is not needed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -127,11 +127,3 @@ services:
     logging: *default-logging
     restart: always
 
-  vendor-proxy:
-    image: lblod/vendor-proxy-service:0.1.0
-    environment:
-      QUERY_BASE_URL: 'https://mandatenbeheer.lblod.info'
-      VENDOR_KEY: '1e328f96-ebd5-42d8-9c40-f451417858ff'
-      VENDOR_URI: 'http://data.lblod.info/vendors/75ad4503-1699-4e43-8cab-a494142ae571'
-      AUTH_GROUP: 'org'
-


### PR DESCRIPTION
### Overview
~The `org` group does not exist on RB, so use `org-wf` instead.~
Remove vendor-proxy service as templates should be municipality agnostic, so it is not needed.

##### connected issues and PRs:
From Jira: https://binnenland.atlassian.net/browse/GN-5018

### Setup
N/A

### How to test/reproduce
Run the stack, insert a person variable and when inserting the person, verify that the modal is populated.

### Challenges/uncertainties
N/A

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
