### PR TITLE
removed vendor key from docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
     image: lblod/vendor-proxy-service:0.1.0
     environment:
       QUERY_BASE_URL: 'https://mandatenbeheer.lblod.info'
-      VENDOR_KEY: '1e328f96-ebd5-42d8-9c40-f451417858ff'
+      VENDOR_KEY: 'secret'
       VENDOR_URI: 'http://data.lblod.info/vendors/75ad4503-1699-4e43-8cab-a494142ae571'
       AUTH_GROUP: 'org'
 


### PR DESCRIPTION
The vendor key from QA got merged by accident, QA is open with mock login and data there should be anonymized so this shouldn't be a problem, but wanted to revert to the correct docker compose. 
Let me know if I should rewrite history or tell Karel to invalidate the key, but I think is not needed