### PR TITLE
GN-5055: adjust data-model for connected snippet lists

### DIFF
--- a/.changeset/funny-panthers-give.md
+++ b/.changeset/funny-panthers-give.md
@@ -1,0 +1,9 @@
+---
+"app-reglementaire-bijlage": minor
+---
+
+Extend/generalize connected snippet-list feature:
+- Rename `snippet-lists` JSON:API relationship defined on `document-container` to `linked-snippet-lists`
+- Add `linked-snippet-lists` JSON:API relationship to `snippet` data-model
+- Remove unused `templates` JSON:API relationship of `snippet-list` data-model
+

--- a/config/migrations/20241119115649-remodel-linked-snippet-lists.sparql
+++ b/config/migrations/20241119115649-remodel-linked-snippet-lists.sparql
@@ -1,0 +1,18 @@
+PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
+
+DELETE {
+  GRAPH ?g {
+    ?documentContainer ext:hasSnippetLists ?list.
+  }
+}
+INSERT {
+  GRAPH ?g  {
+    ?documentContainer ext:linkedSnippetList ?list.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?documentContainer a ext:DocumentContainer.
+    ?documentContainer ext:hasSnippetLists ?list.
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -232,12 +232,6 @@
           "predicate": "say:hasSnippet",
           "target": "snippet",
           "cardinality": "many"
-        },
-        "templates": {
-          "predicate": "ext:hasSnippetLists",
-          "target": "document-container",
-          "cardinality": "many",
-          "inverse": true
         }
       },
       "features": ["include-uri"],
@@ -276,6 +270,11 @@
           "target": "snippet-list",
           "cardinality": "one",
           "inverse": true
+        },
+        "linked-snippet-lists": {
+          "predicate": "ext:linkedSnippetList",
+          "target": "snippet-list",
+          "cardinality": "many"
         }
       },
       "features": ["include-uri"],

--- a/config/resources/editor.json
+++ b/config/resources/editor.json
@@ -78,8 +78,8 @@
               "target": "editor-document",
               "cardinality": "many"
             },
-            "snippet-lists": {
-              "predicate": "ext:hasSnippetLists",
+            "linked-snippet-lists": {
+              "predicate": "ext:linkedSnippetList",
               "target": "snippet-list",
               "cardinality": "many"
             }


### PR DESCRIPTION
### Overview
This PR slightly adjusts the data-model for connected snippet lists:
- Rename `snippet-lists` JSON:API relationship defined on `document-container` to `linked-snippet-lists` for clarity
- Add `linked-snippet-lists` JSON:API relationship to `snippet` data-model
- Remove unused `templates` JSON:API relationship of `snippet-list` data-model

This PR also adds a migration which renames the `ext:hasSnippetLists` predicate to `ext:linkedSnippetList` for clarity.

##### connected issues and PRs:
[GN-5055](https://binnenland.atlassian.net/browse/GN-5055)
https://github.com/lblod/frontend-reglementaire-bijlage/pull/299

### How to test/reproduce
- Ensure the migration has run successfully
- The `/snippets` and `/document-containers` JSON:API routes should now also provide (now mostly empty) `linked-snippet-lists` relationships

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
