### PR TITLE
Correct template version schema:validThrough to be an xsd:dateTime

### DIFF
--- a/.changeset/tasty-olives-decide.md
+++ b/.changeset/tasty-olives-decide.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": minor
+---
+
+Correct schema:validThrough relationship of Template Version to be an xsd:dateTime

--- a/config/migrations/20241201161825-template-expiry-fix.sparql
+++ b/config/migrations/20241201161825-template-expiry-fix.sparql
@@ -1,0 +1,22 @@
+PREFIX schema: <http://schema.org/>      
+PREFIX gn: <http://data.lblod.info/vocabularies/gelinktnotuleren/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+DELETE {
+  GRAPH ?g {
+    ?templateVersion schema:validThrough ?validThrough.
+  }
+}
+INSERT {
+  GRAPH ?g {
+    ?templateVersion schema:validThrough ?vtDate.
+  }
+}
+WHERE {
+  GRAPH ?g {
+    ?templateVersion a gn:TemplateVersie;
+        schema:validThrough ?validThrough.
+    FILTER (DATATYPE(?validThrough) = xsd:string).
+    BIND (STRDT(?validThrough, xsd:dateTime) as ?vtDate).
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -89,7 +89,7 @@
       },
       "attributes": {
         "valid-through": {
-          "type": "string",
+          "type": "datetime",
           "predicate": "schema:validThrough"
         },
         "title": {


### PR DESCRIPTION
### Overview
Unpublishing templates, while not possible in the UI, was technically possible, but the config of resources was incorrect for it to actually work. With these as `xsd:dateTime`s, the comparison to `NOW()` actually works.

This has the consequence that there are templates that have a string `schema:validThrough`, which are still available in GN, but after this change will not be. Looking at prod, these seem to be templates with 'test' in the name, but we need to confirm that these templates indeed should not be present.

##### connected issues and PRs:
Jira ticket for new feature needing this: https://binnenland.atlassian.net/browse/GN-5192

### Setup
Run GN pointing to your local RB, first without this change, then after to verify the fix. Easiest is if you have data that already has string `validThrough` relationships, such as that on prod or QA.

### How to test/reproduce
Before applying this change, open the modal to create a new agendapoint or regulatory statement. Notice that the `validThrough` relation is ignored and all the templates show in the powerselect.
After this change, any of these templates with a `validThrough` in the past should not appear in the list.

### Challenges/uncertainties
It's weird that these templates have remained visible for so long without anyone commenting on them...

### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
