### PR TITLE
Add support for mu-tasks

### DIFF
--- a/.changeset/lemon-planes-heal.md
+++ b/.changeset/lemon-planes-heal.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": minor
+---
+
+Add `task`, `job` and `job-error` models to resources config

--- a/.changeset/spicy-worms-report.md
+++ b/.changeset/spicy-worms-report.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Add migration which introduces more generic task status-URIs

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -101,6 +101,9 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/DocumentContainer",
                         "http://mu.semte.ch/vocabularies/ext/Concept",
                         "http://mu.semte.ch/vocabularies/ext/Mapping",
+                        "http://vocab.deri.ie/cogs#Job",
+                        "http://open-services.net/ns/core#Error",
+                        "http://redpencil.data.gift/vocabularies/tasks/Task",
                       ] } } ] },
 
       # // CLEANUP

--- a/config/dispatcher/dispatcher.ex
+++ b/config/dispatcher/dispatcher.ex
@@ -64,6 +64,18 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://cache/snippet-versions/"
   end
 
+  get "/tasks/*path", %{ accept: %{json: true}, layer: :api} do
+    Proxy.forward conn, path, "http://cache/tasks/"
+  end
+
+  get "/jobs/*path", %{ accept: %{json: true}, layer: :api} do
+    Proxy.forward conn, path, "http://cache/jobs/"
+  end
+
+  get "/job-errors/*path", %{ accept: %{json: true}, layer: :api} do
+    Proxy.forward conn, path, "http://cache/job-errors/"
+  end
+
   post "/publish-template/*path", %{ accept: %{json: true}, layer: :api} do
     Proxy.forward conn, path, "http://publisher/publish-template/"
   end
@@ -72,9 +84,7 @@ defmodule Dispatcher do
     Proxy.forward conn, path, "http://publisher/snippet-list-publication-tasks/"
   end
 
-  get "/tasks/*path", %{ accept: %{json: true}, layer: :api} do
-    Proxy.forward conn, path, "http://publisher/tasks/"
-  end
+
 
   match "/codex/sparql/*path" do
     forward conn, path, "http://codex-proxy/sparql/"

--- a/config/migrations/20241210133229-use-generic-task-statuses.sparql
+++ b/config/migrations/20241210133229-use-generic-task-statuses.sparql
@@ -1,0 +1,19 @@
+DELETE {
+  GRAPH ?g {
+
+  }
+}
+INSERT {
+  GRAPH ?g {
+
+  }
+}
+WHERE {
+  VALUES (?oldStatus ?newStatus) {
+    (<http://lblod.data.gift/besluit-publicatie-melding-statuses/created> <http://redpencil.data.gift/id/concept/JobStatus/scheduled>)
+    (<http://lblod.data.gift/besluit-publicatie-melding-statuses/ongoing> <http://redpencil.data.gift/id/concept/JobStatus/busy>)
+    (<http://lblod.data.gift/besluit-publicatie-melding-statuses/success> <http://redpencil.data.gift/id/concept/JobStatus/success>)
+    (<http://lblod.data.gift/besluit-publicatie-melding-statuses/failure> <http://redpencil.data.gift/id/concept/JobStatus/failed>)
+  }
+  
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -13,42 +13,6 @@
     "say": "https://say.data.gift/ns/"
   },
   "resources": {
-    "files": {
-      "name": "file",
-      "class": "nfo:FileDataObject",
-      "attributes": {
-        "name": {
-          "type": "string",
-          "predicate": "nfo:fileName"
-        },
-        "format": {
-          "type": "string",
-          "predicate": "dct:format"
-        },
-        "size": {
-          "type": "number",
-          "predicate": "nfo:fileSize"
-        },
-        "extension": {
-          "type": "string",
-          "predicate": "dbpedia:fileExtension"
-        },
-        "created": {
-          "type": "datetime",
-          "predicate": "nfo:fileCreated"
-        }
-      },
-      "relationships": {
-        "download": {
-          "predicate": "nie:dataSource",
-          "target": "file",
-          "cardinality": "one",
-          "inverse": true
-        }
-      },
-      "features": ["include-uri"],
-      "new-resource-base": "http://data.example.com/files/"
-    },
     "templates": {
       "name": "template",
       "class": "gn:Template",

--- a/config/resources/domain.lisp
+++ b/config/resources/domain.lisp
@@ -9,6 +9,7 @@
 (defparameter *cache-count-queries* t)
 
 ;; reading in the domain.json
+(read-domain-file "generic.json")
 (read-domain-file "domain.json")
 (read-domain-file "auth.json")
 (read-domain-file "editor.json")

--- a/config/resources/generic.json
+++ b/config/resources/generic.json
@@ -1,0 +1,144 @@
+{
+  "version": "0.1",
+  "prefixes": {
+    "nfo": "http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#",
+    "dct": "http://purl.org/dc/terms/",
+    "dbpedia": "http://dbpedia.org/ontology/",
+    "nie": "http://www.semanticdesktop.org/ontologies/2007/01/19/nie#",
+    "cogs": "http://vocab.deri.ie/cogs#",
+    "adms": "http://www.w3.org/ns/adms#",
+    "task": "http://redpencil.data.gift/vocabularies/tasks/",
+    "oslc": "http://open-services.net/ns/core#"
+  },
+  "resources": {
+    "files": {
+      "name": "file",
+      "class": "nfo:FileDataObject",
+      "attributes": {
+        "name": {
+          "type": "string",
+          "predicate": "nfo:fileName"
+        },
+        "format": {
+          "type": "string",
+          "predicate": "dct:format"
+        },
+        "size": {
+          "type": "number",
+          "predicate": "nfo:fileSize"
+        },
+        "extension": {
+          "type": "string",
+          "predicate": "dbpedia:fileExtension"
+        },
+        "created": {
+          "type": "datetime",
+          "predicate": "nfo:fileCreated"
+        }
+      },
+      "relationships": {
+        "download": {
+          "predicate": "nie:dataSource",
+          "target": "file",
+          "cardinality": "one",
+          "inverse": true
+        }
+      },
+      "features": ["include-uri"],
+      "new-resource-base": "http://data.example.com/files/"
+    },
+    "jobs": {
+      "name": "job",
+      "class": "cogs:Job",
+      "attributes": {
+        "created": {
+          "type": "datetime",
+          "predicate": "dct:created"
+        },
+        "modified": {
+          "type": "datetime",
+          "predicate": "dct:modified"
+        },
+        "creator": {
+          "type": "url",
+          "predicate": "dct:creator"
+        },
+        "status": {
+          "type": "url",
+          "predicate": "adms:status"
+        },
+        "operation": {
+          "type": "url",
+          "predicate": "task:operation"
+        }
+      },
+      "relationships": {
+        "job-error": {
+          "target": "job-error",
+          "cardinality": "one",
+          "predicate": "task:error"
+        },
+        "tasks": {
+          "target": "task",
+          "cardinality": "many",
+          "predicate": "dct:isPartOf",
+          "inverse": true
+        }
+      },
+      "features": ["include-uri"],
+      "new-resource-base": "http://redpencil.data.gift/id/job/"
+    },
+    "job-errors": {
+      "name": "job-error",
+      "class": "oslc:Error",
+      "attributes": {
+        "message": {
+          "type": "string",
+          "predicate": "oslc:message"
+        }
+      },
+      "features": ["include-uri"],
+      "new-resource-base": "http://redpencil.data.gift/id/jobs/error/"
+    },
+    "tasks": {
+      "name": "task",
+      "class": "task:Task",
+      "attributes": {
+        "created": {
+          "type": "datetime",
+          "predicate": "dct:created"
+        },
+        "modified": {
+          "type": "datetime",
+          "predicate": "dct:modified"
+        },
+        "status": {
+          "type": "url",
+          "predicate": "adms:status"
+        },
+        "operation": {
+          "type": "url",
+          "predicate": "task:operation"
+        },
+        "index": {
+          "type": "string",
+          "predicate": "task:index"
+        }
+      },
+      "relationships": {
+        "job-error": {
+          "target": "job-error",
+          "cardinality": "one",
+          "predicate": "task:error"
+        },
+        "job": {
+          "target": "job",
+          "cardinality": "one",
+          "predicate": "dct:isPartOf"
+        }
+      },
+      "features": ["include-uri"],
+      "new-resource-base": "http://redpencil.data.gift/id/task/"
+    }
+  }
+}


### PR DESCRIPTION
### Overview
This PR includes two changes related to mu-tasks:
- A migration which moves their status-URIs to a more generic domain
- Support for `tasks`, `jobs` and `job-errors` in mu-cl-resources and mu-auth

##### connected issues and PRs:
https://github.com/lblod/frontend-reglementaire-bijlage/pull/307
https://github.com/lblod/reglement-publish-service/pull/19


### Setup
Requires both:
- https://github.com/lblod/frontend-reglementaire-bijlage/pull/307
- https://github.com/lblod/reglement-publish-service/pull/19

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
