### PR TITLE
mu-auth: add missing types to org-wf graph-spec

### DIFF
--- a/.changeset/lovely-tomatoes-sell.md
+++ b/.changeset/lovely-tomatoes-sell.md
@@ -1,0 +1,8 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+mu-auth - add the following types to the `org-wf` graph-spec:
+- `http://vocab.deri.ie/cogs#Job`
+- `http://open-services.net/ns/core#Error`
+- `http://redpencil.data.gift/vocabularies/tasks/Task`

--- a/config/authorization/config.ex
+++ b/config/authorization/config.ex
@@ -101,6 +101,9 @@ defmodule Acl.UserGroups.Config do
                         "http://mu.semte.ch/vocabularies/ext/DocumentContainer",
                         "http://mu.semte.ch/vocabularies/ext/Concept",
                         "http://mu.semte.ch/vocabularies/ext/Mapping",
+                        "http://vocab.deri.ie/cogs#Job",
+                        "http://open-services.net/ns/core#Error",
+                        "http://redpencil.data.gift/vocabularies/tasks/Task",
                       ] } } ] },
 
       # // CLEANUP


### PR DESCRIPTION
### Overview
This PR adds the following types to the `org-wf` graph-spec:
- `http://vocab.deri.ie/cogs#Job`
- `http://open-services.net/ns/core#Error`
- `http://redpencil.data.gift/vocabularies/tasks/Task`

Adding these types will allow the `reglement-publish-service` to send queries without the `sudo` header.

##### connected issues and PRs:



### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
<!-- a good description how to test what you implemented, starting from an *empty* database. use steps (1. 2. etc) -->

### Challenges/uncertainties
<!-- any notes for the reviewer to put special attention to or decisions that were made -->



### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
