### PR TITLE
internal: remove `previous-version` and `next-version` relationships

### DIFF
--- a/.changeset/small-lemons-end.md
+++ b/.changeset/small-lemons-end.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Add migration which removes `pav:previousVersion` relationships from triplestore

--- a/.changeset/sweet-donuts-pretend.md
+++ b/.changeset/sweet-donuts-pretend.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Update frontend to version 9.15.4

--- a/.changeset/thick-tools-greet.md
+++ b/.changeset/thick-tools-greet.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Remove `previous-version` and `next-version` relationships from editor-document and snippet-version models

--- a/config/migrations/20250114131523-remove-document-linked-list-rels.sparql
+++ b/config/migrations/20250114131523-remove-document-linked-list-rels.sparql
@@ -1,0 +1,7 @@
+PREFIX pav: <http://purl.org/pav/>
+
+DELETE WHERE {
+  GRAPH ?g {
+    ?version1 pav:previousVersion ?version2 .
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -248,11 +248,6 @@
       "name": "snippet-version",
       "class": "say:SnippetVersion",
       "relationships": {
-        "previous-version": {
-          "predicate": "pav:previousVersion",
-          "target": "snippet-version",
-          "cardinality": "one"
-        },
         "snippet": {
           "predicate": "pav:hasVersion",
           "target": "snippet",

--- a/config/resources/editor.json
+++ b/config/resources/editor.json
@@ -40,17 +40,6 @@
             }
         },
         "relationships": {
-          "previous-version": {
-            "predicate": "pav:previousVersion",
-            "target": "editor-document",
-            "cardinality": "one"
-          },
-          "next-version": {
-            "predicate": "pav:previousVersion",
-            "target": "editor-document",
-            "cardinality": "one",
-            "inverse": true
-          },
           "document-container": {
             "predicate": "pav:hasVersion",
             "target": "document-container",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-logging: &default-logging
     max-file: "3"
 services:
   frontend:
-    image: lblod/frontend-reglementaire-bijlage:9.15.3
+    image: lblod/frontend-reglementaire-bijlage:9.15.4
     restart: always
     environment:
       EMBER_OAUTH_API_REDIRECT_URL: "https://reglementairebijlagen.lblod.info/authorization/callback"


### PR DESCRIPTION
### Overview
This PR includes the following changes:
- Adapation to the `snippet-version` and `editor-document` models to no longer include the unneeded/unused `previous-version` and `next-version` relationships
- A migration which removes all `pav:previousVersion` relationships from the triplestore

This PR is a draft until https://github.com/lblod/frontend-reglementaire-bijlage/pull/313 is merged and released

##### connected issues and PRs:
https://github.com/lblod/frontend-reglementaire-bijlage/pull/313


### Setup
To be used in combination with https://github.com/lblod/frontend-reglementaire-bijlage/pull/313

### How to test/reproduce
- Ensure the migration runs as expected
- Follow the test steps of the frontend PR to ensure the application still works as expected

### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
