### PR TITLE
GN-5143: replace erroneous `prov:derivedFrom` by `prov:wasDerivedFrom`

### DIFF
--- a/.changeset/beige-ducks-report.md
+++ b/.changeset/beige-ducks-report.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Fix: replace erroneous `prov:derivedFrom` predicated by `prov:wasDerivedFrom`

--- a/.changeset/fair-ties-approve.md
+++ b/.changeset/fair-ties-approve.md
@@ -1,0 +1,5 @@
+---
+"app-reglementaire-bijlage": patch
+---
+
+Update `publisher` service to version [5.2.1](https://github.com/lblod/reglement-publish-service/releases/tag/v5.2.1)

--- a/config/migrations/20250128092752-prov-was-derived-from-fix.sparql
+++ b/config/migrations/20250128092752-prov-was-derived-from-fix.sparql
@@ -1,0 +1,18 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+DELETE {
+  GRAPH ?g {
+  	?sub prov:derivedFrom ?obj .
+  }
+}
+INSERT {
+  GRAPH ?g {
+  	?sub prov:wasDerivedFrom ?obj .
+  }
+}
+WHERE {
+  GRAPH ?g {
+  	?sub prov:derivedFrom ?obj .
+  }
+}

--- a/config/resources/domain.json
+++ b/config/resources/domain.json
@@ -28,7 +28,7 @@
           "cardinality": "many"
         },
         "derived-from": {
-          "predicate": "prov:derivedFrom",
+          "predicate": "prov:wasDerivedFrom",
           "target": "document-container",
           "cardinality": "one"
         },
@@ -46,7 +46,7 @@
       "super": ["file"],
       "relationships": {
         "derived-from": {
-          "predicate": "prov:derivedFrom",
+          "predicate": "prov:wasDerivedFrom",
           "target": "editor-document",
           "cardinality": "one"
         }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       BACKEND_HOST: database
     restart: always
   publisher:
-    image: lblod/reglement-publish-service:5.2.0
+    image: lblod/reglement-publish-service:5.2.1
     links:
       - database:database
     volumes:


### PR DESCRIPTION
### Overview
This PR includes a migration and some adjustments to the resource config files to ensure the `prov:wasDerivedFrom` predicate is used instead of the erroneous `prov:derivedFrom`.

##### connected issues and PRs:
[GN-5143](https://binnenland.atlassian.net/browse/GN-5143)
https://github.com/lblod/reglement-publish-service/pull/22


### Setup
Include https://github.com/lblod/reglement-publish-service/pull/22 in your stack

### How to test/reproduce
- Start the stack and ensure the migrations have correctly run
- Ensure all instances of `prov:derivedFrom` have been replaced by `prov:wasDerivedFrom` 
- Publish a template and ensure the correct predicate is used there...


### Checks PR readiness
- [x] UI: works on smaller screen sizes
- [x] UI: feedback for any loading/error states
- [x] Check cancel/go-back flows
- [x] Check database state correct when deleting/updating (especially regarding relationships)
- [x] changelog
- [x] no new deprecations
