### PR TITLE
Update Virtuoso image version to 1.2.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     restart: always
     logging: *default-logging
   virtuoso:
-    image: redpencil/virtuoso:1.2.0-rc.1
+    image: redpencil/virtuoso:1.2.2
     environment:
       SPARQL_UPDATE: "true"
       DEFAULT_GRAPH: "http://mu.semte.ch/application"


### PR DESCRIPTION
### Overview
Bumps virtuoso image to 1.2.2 (see [build](https://build.redpencil.io/repos/170/pipeline/182) , currently still running).
This image has several fixes, among them the removal of the ability to call several built in functions through SPARQL.

##### connected issues and PRs:

### Setup
<!-- PR dependencies -->
<!-- override snippets -->

### How to test/reproduce
Contact me for reproduction steps.

### Challenges/uncertainties
Even though the changes are minimal and shouldn't affect regular queries, make sure to check the app still works fine.


### Checks PR readiness
- [ ] UI: works on smaller screen sizes
- [ ] UI: feedback for any loading/error states
- [ ] Check cancel/go-back flows
- [ ] Check database state correct when deleting/updating (especially regarding relationships)
- [ ] changelog
- [ ] no new deprecations
